### PR TITLE
fix: added alpine based image and caching in the Dockerfile

### DIFF
--- a/part-1/1-simple-app/Dockerfile
+++ b/part-1/1-simple-app/Dockerfile
@@ -1,14 +1,20 @@
-FROM node:20
+FROM node:19.6-alpine
 
 WORKDIR /usr/src/app
 
-COPY . .
+ENV NODE_ENV production
 
-RUN npm install
+COPY package*.json ./
+
+RUN --mount=type=cache,target=/usr/src/app/.npm npm set cache /usr/src/app/.npm && \
+    npm ci --only=production
+
+USER node
+
+COPY --chown=node:node ./src .
 
 EXPOSE 3000
 
 CMD ["node", "index.js"]
-
 
 


### PR DESCRIPTION
I added an alpine based image to reduce the overall size of the container and improved caching by using npm ci(clean install) instead of normal npm install